### PR TITLE
Add exclude, verbosity, and dry-run options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,170 @@
+
+Tags
+
+
+# Created by https://www.gitignore.io/api/macos,linux,emacs,sublimetext,haskell
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+projectile-bookmarks.eld
+
+# directory configuration
+.dir-locals.el
+
+# saveplace
+places
+
+# url cache
+url/cache/
+
+# cedet
+ede-projects.el
+
+# smex
+smex-items
+
+# company-statistics
+company-statistics-cache.el
+
+# anaconda-mode
+anaconda-mode/
+
+### Haskell ###
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+.HTF/
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### SublimeText ###
+# cache files for sublime text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+
+# End of https://www.gitignore.io/api/macos,linux,emacs,sublimetext,haskell
+

--- a/main.hs
+++ b/main.hs
@@ -10,12 +10,12 @@ main :: IO ExitCode
 main = do
   cmd <- cmdArgsRun $ cmdArgsMode tb
   time <- getCurrentTime
-  let d = utctDay time
-  let cl = cleanup cmd
-  let fr = whichType (frequency cmd) d
-  let cl_type = whatCleanup fr
-  rc <- doBackup (show fr) d (dir cmd)
-  let n = retain cmd
+  let day = utctDay time
+      cl = cleanup cmd
+      fr = autoFrequency (frequency cmd) day
+      cl_type = whatCleanup fr
+      n = retain cmd
+  rc <- doBackup fr (dryrun cmd) (verbose cmd) (exclude cmd) day (dir cmd)
   case rc of
     ExitFailure _ -> exitWith rc
     ExitSuccess ->
@@ -23,5 +23,5 @@ main = do
         then case cl_type of
                Nothing -> exitWith rc
                Just f ->
-                 doCleanup (last (splitDirectories (dir cmd))) f n >> exitWith rc
+                 doCleanup f (dryrun cmd) (verbose cmd) (last (splitDirectories (dir cmd))) n >> exitWith rc
         else exitWith rc

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.13
+resolver: lts-11.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test.hs
+++ b/test.hs
@@ -35,7 +35,7 @@ instance Arbitrary Day where
     return $ fromGregorian year month day
 
 prop_correct_auto_frequency :: Frequency -> Day -> Bool
-prop_correct_auto_frequency f d = whichType f d == f
+prop_correct_auto_frequency f d = autoFrequency f d == f
 
 genFiles :: Gen String
 genFiles =


### PR DESCRIPTION
This pull request, albeit somewhat wordy, adds 3 options to tarsnap-backup allowing users to make it `verbose`, add `exclude` patterns to ignore unnecessary files, and test the backup on big directories with `dryrun`

Hope the style of this code does not interfere with what you would usually accept.